### PR TITLE
feat: implement global 404 and 500 error pages and add Suspense boundaries to MDX content rendering

### DIFF
--- a/app/[project]/page.tsx
+++ b/app/[project]/page.tsx
@@ -6,6 +6,7 @@ import { evaluate } from "nextra/evaluate";
 import { MainLayout } from "@/components/MainLayout";
 import { getAllProjects, getProject } from "@/lib/projects";
 import { useMDXComponents } from "../../mdx-components";
+import { Suspense } from "react";
 
 interface PageProps {
   params: Promise<{
@@ -50,25 +51,33 @@ export async function generateStaticParams() {
   return [...projectParams, ...contentParams];
 }
 
+async function CompiledContent({ projectId, localContent }: { projectId: string; localContent: string }) {
+  const components = useMDXComponents({});
+  const compiledSource = await compileMdx(localContent, {
+    filePath: `content/${projectId}.mdx`,
+    defaultShowCopyCode: true,
+    codeHighlight: true,
+  });
+
+  const { default: MDXContent } = evaluate(compiledSource, components);
+
+  return (
+    <MainLayout>
+      <MDXContent />
+    </MainLayout>
+  );
+}
+
 export default async function ProjectPage({ params }: PageProps) {
   const { project: projectId } = await params;
-  const components = useMDXComponents({});
 
   // Check for local content first
   const localContent = getLocalContent(projectId);
   if (localContent) {
-    const compiledSource = await compileMdx(localContent, {
-      filePath: `content/${projectId}.mdx`,
-      defaultShowCopyCode: true,
-      codeHighlight: true,
-    });
-
-    const { default: MDXContent } = evaluate(compiledSource, components);
-
     return (
-      <MainLayout>
-        <MDXContent />
-      </MainLayout>
+      <Suspense fallback={<MainLayout><div className="p-12 text-center opacity-50 font-mono text-sm uppercase tracking-widest">[ COMPILING_MDX... ]</div></MainLayout>}>
+        <CompiledContent projectId={projectId} localContent={localContent} />
+      </Suspense>
     );
   }
 

--- a/app/collective/[...slug]/page.tsx
+++ b/app/collective/[...slug]/page.tsx
@@ -5,6 +5,7 @@ import { compileMdx } from "nextra/compile";
 import { evaluate } from "nextra/evaluate";
 import { getWhitepaperIssueCounts } from "@/lib/whitepapers";
 import { useMDXComponents } from "../../../mdx-components";
+import { Suspense } from "react";
 
 interface PageProps {
   params: Promise<{
@@ -65,15 +66,8 @@ export async function generateStaticParams() {
   return collectSlugs(CONTENT_ROOT).map((slug) => ({ slug }));
 }
 
-export default async function CollectivePage({ params }: PageProps) {
-  const { slug } = await params;
+async function CompiledCollectiveSlugContent({ slug, found }: { slug: string[]; found: { content: string; relPath: string } }) {
   const components = useMDXComponents({});
-
-  const found = getCollectiveContent(slug);
-  if (!found) {
-    notFound();
-  }
-
   const compiledSource = await compileMdx(found.content, {
     filePath: `content/collective/${found.relPath}`,
     defaultShowCopyCode: true,
@@ -88,12 +82,6 @@ export default async function CollectivePage({ params }: PageProps) {
 
   const { CollectiveWrapper } = await import("@/components/CollectiveWrapper");
 
-  // Read the build-time issue counts for this whitepaper from the
-  // manifest (populated by the daily 00:15 UTC deploy via
-  // scripts/generate-whitepapers-manifest.ts). The page is a server
-  // component, so we can read the file directly and pass the counts
-  // through the wrapper into the client widget as static initial
-  // state — no runtime fetch from the browser.
   const isWhitepaperPage = slug[0] === "whitepapers" && slug.length >= 2;
   const issueCounts = isWhitepaperPage
     ? getWhitepaperIssueCounts(slug[slug.length - 1])
@@ -109,5 +97,20 @@ export default async function CollectivePage({ params }: PageProps) {
     >
       <MDXContent />
     </CollectiveWrapper>
+  );
+}
+
+export default async function CollectivePage({ params }: PageProps) {
+  const { slug } = await params;
+
+  const found = getCollectiveContent(slug);
+  if (!found) {
+    notFound();
+  }
+
+  return (
+    <Suspense fallback={<div className="p-12 text-center opacity-50 font-mono text-sm uppercase tracking-widest">[ COMPILING_MDX... ]</div>}>
+      <CompiledCollectiveSlugContent slug={slug} found={found} />
+    </Suspense>
   );
 }

--- a/app/collective/page.tsx
+++ b/app/collective/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation";
 import { compileMdx } from "nextra/compile";
 import { evaluate } from "nextra/evaluate";
 import { useMDXComponents } from "../../mdx-components";
+import { Suspense } from "react";
 
 function getIndexContent(): string | null {
   const mdxPath = path.join(
@@ -22,11 +23,8 @@ function getIndexContent(): string | null {
   return null;
 }
 
-export default async function CollectiveIndexPage() {
+async function CompiledCollectiveContent({ content }: { content: string }) {
   const components = useMDXComponents({});
-  const content = getIndexContent();
-  if (!content) notFound();
-
   const compiledSource = await compileMdx(content, {
     filePath: "content/collective/index.mdx",
     defaultShowCopyCode: true,
@@ -49,5 +47,16 @@ export default async function CollectiveIndexPage() {
     >
       <MDXContent />
     </CollectiveWrapper>
+  );
+}
+
+export default async function CollectiveIndexPage() {
+  const content = getIndexContent();
+  if (!content) notFound();
+
+  return (
+    <Suspense fallback={<div className="p-12 text-center opacity-50 font-mono text-sm uppercase tracking-widest">[ COMPILING_MDX... ]</div>}>
+      <CompiledCollectiveContent content={content} />
+    </Suspense>
   );
 }

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { useEffect } from "react";
+import Custom500 from "@/components/500";
+
+export default function ErrorPage({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    // Log the error to an error reporting service
+    console.error("Application error:", error);
+  }, [error]);
+
+  return <Custom500 />;
+}

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,5 @@
+import Custom404 from "@/components/404";
+
+export default function NotFound() {
+  return <Custom404 />;
+}

--- a/components/404.tsx
+++ b/components/404.tsx
@@ -1,0 +1,43 @@
+import Head from "next/head";
+import Link from "next/link";
+import { MainLayout } from "@/components/MainLayout";
+import { PageTransition } from "@/components/ui/motion";
+
+export default function Custom404() {
+  return (
+    <>
+      <Head>
+        <title>404 - Not Found | Nano Collective</title>
+        <meta name="robots" content="noindex" />
+      </Head>
+      <MainLayout showSidebar={false}>
+        <div className="flex-1 flex flex-col bg-background font-sans">
+          <PageTransition className="flex-1 flex flex-col items-center justify-center container mx-auto px-4 md:px-6 py-12 md:py-24 text-center min-h-[70vh]">
+          <div className="space-y-8 max-w-4xl w-full">
+            <div className="inline-block border-2 border-foreground/20 px-4 py-2 bg-muted/50 font-mono text-sm font-bold uppercase tracking-widest text-[#0000EE] dark:text-[#A1A1AA]">
+              [ SYSTEM ERROR ]
+            </div>
+            
+            <h1 className="text-[8rem] sm:text-[12rem] lg:text-[16rem] leading-none font-bold tracking-tighter text-foreground">
+              404
+            </h1>
+            
+            <p className="text-xl sm:text-3xl font-mono text-foreground/70 uppercase tracking-widest">
+              The coordinates you requested do not exist in this sector.
+            </p>
+
+            <div className="pt-12">
+              <Link 
+                href="/"
+                className="inline-flex items-center justify-center px-8 py-4 sm:px-12 sm:py-6 bg-foreground text-background font-mono font-bold uppercase tracking-widest text-sm sm:text-lg border-2 border-foreground hover:bg-[#0000EE] dark:hover:bg-white dark:hover:text-black transition-colors"
+              >
+                &gt; RETURN_HOME
+              </Link>
+            </div>
+            </div>
+          </PageTransition>
+        </div>
+      </MainLayout>
+    </>
+  );
+}

--- a/components/500.tsx
+++ b/components/500.tsx
@@ -1,0 +1,43 @@
+import Head from "next/head";
+import Link from "next/link";
+import { MainLayout } from "@/components/MainLayout";
+import { PageTransition } from "@/components/ui/motion";
+
+export default function Custom500() {
+  return (
+    <>
+      <Head>
+        <title>500 - Server Error | Nano Collective</title>
+        <meta name="robots" content="noindex" />
+      </Head>
+      <MainLayout showSidebar={false}>
+        <div className="flex-1 flex flex-col bg-background font-sans">
+          <PageTransition className="flex-1 flex flex-col items-center justify-center container mx-auto px-4 md:px-6 py-12 md:py-24 text-center min-h-[70vh]">
+          <div className="space-y-8 max-w-4xl w-full">
+            <div className="inline-block border-2 border-[#ff0000]/40 px-4 py-2 bg-[#ff0000]/10 font-mono text-sm font-bold uppercase tracking-widest text-[#ff0000]">
+              [ SERVER FAULT ]
+            </div>
+            
+            <h1 className="text-[8rem] sm:text-[12rem] lg:text-[16rem] leading-none font-bold tracking-tighter text-foreground">
+              500
+            </h1>
+            
+            <p className="text-xl sm:text-3xl font-mono text-foreground/70 uppercase tracking-widest">
+              An unexpected anomaly occurred on our servers.
+            </p>
+
+            <div className="pt-12">
+              <Link 
+                href="/"
+                className="inline-flex items-center justify-center px-8 py-4 sm:px-12 sm:py-6 bg-foreground text-background font-mono font-bold uppercase tracking-widest text-sm sm:text-lg border-2 border-foreground hover:bg-[#0000EE] dark:hover:bg-white dark:hover:text-black transition-colors"
+              >
+                &gt; RETRY_CONNECTION
+              </Link>
+            </div>
+            </div>
+          </PageTransition>
+        </div>
+      </MainLayout>
+    </>
+  );
+}


### PR DESCRIPTION
### Screen Shot
<img width="1608" height="1566" alt="image" src="https://github.com/user-attachments/assets/5809767e-ab89-429d-8770-29687eb87373" />
