### PR TITLE
docs: ingest prompt-scrub docs tree

### DIFF
--- a/content/collective/whitepapers/prompt-scrubber/community.md
+++ b/content/collective/whitepapers/prompt-scrubber/community.md
@@ -1,0 +1,22 @@
+---
+title: "Community"
+description: "Join the Nano Collective community"
+sidebar_order: 3
+---
+
+# Community
+
+We are building a community around privacy-respecting, local-first tools. Here is how you can get involved:
+
+## Discord
+Join the conversation, ask questions, and share what you've built with `prompt-scrub` on the [Nano Collective Discord](https://discord.gg/ktPDV6rekE).
+
+## Contributing
+We welcome contributions! Please read our [Contributing Guide](../CONTRIBUTING.md) to get started with the codebase.
+
+## Issues
+Found a bug or have an idea? Please use our templates:
+- [Report a Bug](../.github/ISSUE_TEMPLATE/bug_report.md)
+- [Request a Feature](../.github/ISSUE_TEMPLATE/feature_request.md)
+
+*Note: GitHub Discussions are not yet enabled on this repository.*

--- a/content/collective/whitepapers/prompt-scrubber/features/architecture.md
+++ b/content/collective/whitepapers/prompt-scrubber/features/architecture.md
@@ -1,0 +1,55 @@
+---
+title: "Architecture"
+description: "Documentation for Architecture"
+sidebar_order: 1
+---
+
+# Architecture: prompt-scrub
+
+## High-Level Structure
+
+```text
+prompt-scrub
+├── src/
+│   ├── detectors/
+│   │   ├── email.ts
+│   │   ├── phone.ts
+│   │   ├── path.ts
+│   │   ├── secret.ts
+│   │   └── url.ts
+│   │
+│   ├── session/
+│   │   ├── session-manager.ts
+│   │   └── storage.ts
+│   │
+│   ├── core/
+│   │   ├── scrub.ts
+│   │   ├── rehydrate.ts
+│   │   └── collision-resolver.ts
+│   │
+│   ├── cli/
+│   │   └── commands/
+│   │
+│   └── types/
+```
+
+## Core Components
+
+- **Detectors (`src/detectors/`)**: Pluggable modules responsible for finding identifying information (emails, paths, secrets, etc.) in text and returning standard `Finding` objects.
+- **Session Management (`src/session/`)**: Handles creating, loading, and saving session maps to disk (JSON format). Ensures that identifiers remain consistently mapped across a session.
+- **Core Pipeline (`src/core/`)**:
+  - `scrub.ts`: Orchestrates the detection process, resolves collisions, applies replacements, and updates the session map.
+  - `rehydrate.ts`: The reverse process; swaps placeholders back to their original values using the session map.
+  - `collision-resolver.ts`: Logic to handle overlapping findings from different detectors (the more specific detector wins).
+- **CLI (`src/cli/`)**: Command-line interface wrapping the core library. Exposes commands like `scrub`, `rehydrate`, `inspect`, and session management.
+- **Types (`src/types/`)**: Shared TypeScript interfaces (e.g., `Message`, `Finding`, `SessionMap`).
+
+## Data Flow: The `scrub()` Pipeline
+
+A single `scrub()` call flows through a five-step pipeline:
+
+1. **Accept the message**: `scrub()` accepts a string or an array of OpenAI-shaped `{ role, content }` objects.
+2. **Stabilise the session map**: If a session ID is provided, the existing map is loaded from disk (or in-process cache). If not, a new UUID and map are created.
+3. **Run the detector pipeline**: All enabled detectors run in sequence, producing deterministic `Finding` items for the input text based on the active session map.
+4. **Resolve collisions**: If two detectors flag the same or overlapping text, the `collision-resolver` determines the winner based on the defined priority sequence.
+5. **Apply the transformations**: The winning findings are replaced with stable placeholders (e.g., `Email_1`), the updated session map is saved, and the scrubbed message is returned alongside the session ID.

--- a/content/collective/whitepapers/prompt-scrubber/features/detectors.md
+++ b/content/collective/whitepapers/prompt-scrubber/features/detectors.md
@@ -1,0 +1,58 @@
+---
+title: "Detector System"
+description: "Documentation for Detector System"
+sidebar_order: 1
+---
+
+# Detector System
+
+The detector system is responsible for scanning input text, identifying sensitive information, and proposing replacements (placeholders).
+
+## Architecture
+
+Detectors are pluggable functions that conform to the `Detector` interface. They take in the raw text and return a list of `Finding` objects.
+
+```typescript
+export interface Finding {
+  category: string; // e.g., 'Email', 'Phone', 'Secret'
+  span: [number, number]; // [startIndex, endIndex]
+  value: string; // The original matched string
+  placeholderPrefix: string; // The prefix for the placeholder (e.g., 'Email')
+}
+
+export interface Detector {
+  name: string;
+  detect(text: string): Finding[];
+}
+```
+
+## Built-in Detectors
+
+- `EmailDetector`: Detects RFC 5322 shaped email addresses.
+- `PhoneDetector`: Detects international and US-shaped phone numbers.
+- `UrlDetector`: Detects full URLs (with allowlist support).
+- `PathDetector`: Detects absolute paths and home directories.
+- `SecretDetector`: Detects high-entropy strings, API keys, and tokens.
+
+## Priority & Collision System
+
+When multiple detectors flag overlapping spans, a collision resolution system determines which finding wins.
+
+Priority is implicitly handled by a defined order of precedence:
+1. `SecretDetector` (highest priority - missing a secret is dangerous)
+2. `EmailDetector`
+3. `UrlDetector`
+4. `PathDetector`
+5. `PhoneDetector`
+
+If `SecretDetector` and `UrlDetector` match the same string (e.g., a URL with a token), `SecretDetector` wins.
+
+## Registration System
+
+By default, the core scrub function runs the built-in detectors in priority order. You can optionally pass `disabledDetectors` in the `ScrubOptions` to turn off specific built-ins.
+
+### Custom Detectors
+
+Custom detectors can be passed in during the execution of the library by providing them in the `customDetectors` array in the `ScrubOptions` (see `src/types/index.ts`). This effectively overrides or appends to the default list.
+
+*Note: In v1, there is no rule-pack installer or rules CLI surface. All custom detectors must be configured via the library API.*

--- a/content/collective/whitepapers/prompt-scrubber/features/index.md
+++ b/content/collective/whitepapers/prompt-scrubber/features/index.md
@@ -1,0 +1,14 @@
+---
+title: "Features"
+description: "Core features of prompt-scrub"
+sidebar_order: 1
+---
+
+# Features
+
+This section covers the core systems that make `prompt-scrub` work.
+
+- [Architecture](architecture.md): Understand the high-level architecture of the system.
+- [Threat Model](threat-model.md): Learn what `prompt-scrub` defends against and what it does not.
+- [Detectors](detectors.md): See how the pluggable detector system identifies sensitive information.
+- [Session Management](session-management.md): Learn how `prompt-scrub` securely persists placeholder mappings locally.

--- a/content/collective/whitepapers/prompt-scrubber/features/session-management.md
+++ b/content/collective/whitepapers/prompt-scrubber/features/session-management.md
@@ -1,0 +1,38 @@
+---
+title: "Session Management"
+description: "Documentation for Session Management"
+sidebar_order: 1
+---
+
+# Session Management
+
+The session manager is responsible for keeping track of original values and their assigned placeholders, ensuring that the same entity gets the same placeholder throughout a single session.
+
+## Data Structure
+
+A session map is a simple key-value dictionary where the key is the placeholder and the value is the original string.
+
+```json
+{
+  "Email_1": "john@example.com",
+  "Path_1": "/Users/john/project",
+  "Secret_1": "sk-xxxxx"
+}
+```
+
+## Storage Location
+
+Sessions are stored as JSON files on disk in the user's config directory:
+- **macOS**: `~/Library/Application Support/prompt-scrub/sessions/<id>.json`
+- **Linux**: `${XDG_CONFIG_HOME:-~/.config}/prompt-scrub/sessions/<id>.json`
+- **Windows**: `%APPDATA%\prompt-scrub\sessions\<id>.json`
+
+## Lifecycle & Expiry
+
+- **Creation**: Sessions are created on-demand. If no session ID is provided to the CLI or the API, a new one is generated.
+- **Duration**: By default, there is no automatic expiry in v1. The user explicitly controls when sessions are removed via the `prompt-scrub sessions rm <id>` command.
+- **Duplicates**: If a session ID already exists, the manager loads it and appends new identifiers. Existing identifiers maintain their previously assigned placeholder mappings. If the same value is encountered again (e.g., "john@example.com"), the system reuses `Email_1` instead of creating `Email_2`.
+
+## ID Generation
+
+When auto-generated, session IDs are UUIDs (v4) to ensure uniqueness without central coordination.

--- a/content/collective/whitepapers/prompt-scrubber/features/threat-model.md
+++ b/content/collective/whitepapers/prompt-scrubber/features/threat-model.md
@@ -1,0 +1,32 @@
+---
+title: "Threat Model"
+description: "Documentation for Threat Model"
+sidebar_order: 1
+---
+
+# What `prompt-scrub` Is and Isn't (Threat Model)
+
+`prompt-scrub` operates exclusively at the content layer. It modifies the text you send, not how you send it. This document clarifies exactly what the tool defends against, what it partially mitigates, and what it cannot protect you from.
+
+## In Scope (Defended by v1)
+
+- **Accidental secret leakage in prompts**: Strong defense. The secret detector catches the common API key, token, and credential shapes with high precision. Missing a credential is worse than missing a name, and the detector is tuned accordingly.
+- **Accidental identifier leakage in one-off prompts**: Strong defense. Email, phone, postal address, path, and URL detectors catch the obvious shapes with conservative defaults. A user who pastes a prompt with their contact details and a path or two gets clean text out, with the original values on disk under the session map for rehydration.
+
+## Partial Defense (Reduced but not eliminated)
+
+- **Cloud LLM providers reading identifying content in prompts and tool results**: The detectors reduce what is visible. They do not eliminate it: a paragraph that says "my project at `/Users/me/work` has this weird bug" becomes "my project at `Path_1` has this weird bug", which is materially less identifying but not zero.
+- **Long-term provider profile building from prompt content**: Stable session mappings prevent identifier-level correlation across a single session (the same email maps to the same `Email_1` on every turn). They do not address stylistic fingerprinting, and a determined provider can still build a profile across sessions.
+- **Tool call results in agentic settings**: The scrubber operates on every message regardless of origin, so `ls`, `git log`, `cat`, and `grep` results are scrubbed before the next LLM turn. Coverage is limited to the configured detectors (paths, names, URLs, etc.); the host of leaks a clever tool call could produce is not enumerated exhaustively in v1.
+
+## Out of Scope (Not defended by v1)
+
+- **An adversary on the user's machine**: `prompt-scrub` runs locally; if the local environment is compromised, the prompt is too. The session maps on disk are plaintext JSON in v1, and an attacker with the user's account can read them. (Encryption at rest is a v1.1 follow-up).
+- **Semantic leakage**: A question that is inherently identifying (your private codebase, a niche bug only you have, a number only your accountant knows) cannot be made anonymous by stripping identifiers. Stripping identifiers from "what is wrong with my taxes given I made $X this year" does not anonymize the question.
+- **Style fingerprinting**: The v1 brute force approach does not rewrite style. The way you phrase things, the words you choose, the cadence of your questions, all go out unchanged. The phase 2 model-based rewriter is the path to address this; in v1, it is a known gap.
+- **Harmful content moderation**: Not a `prompt-scrub` job. The tool is trying to catch identifying content, not harmful content.
+- **Anything at the network or key layer**: The scrubber does not run on the network and does not see it. A user who needs this protection composes with a network tool of their own choosing (a VPN, Tor, a self-hosted relay, or a proxy).
+
+## Out of scope, and easy to mistake for in-scope
+
+- **Network-level identification of the user's traffic to the LLM provider**: The scrubber does not see the network. IP address, network fingerprint, request timing, headers — all of these are the network layer's problem, and the scrubber cannot help with any of them. A user who needs network-layer privacy composes the scrubber with a network tool. The integration shape is "scrub, send, rehydrate" — a network tool on the request path is additive, not coupled.

--- a/content/collective/whitepapers/prompt-scrubber/getting-started/api.md
+++ b/content/collective/whitepapers/prompt-scrubber/getting-started/api.md
@@ -1,0 +1,81 @@
+---
+title: "V1 Api"
+description: "Documentation for V1 Api"
+sidebar_order: 1
+---
+
+# v1 API Reference
+
+The primary interface for `prompt-scrub` is designed to be simple and stateless from the caller's perspective, delegating session persistence to the library.
+
+## Core Functions
+
+### `scrub`
+
+Scrubs identifying content from a prompt or message.
+
+```typescript
+import { scrub } from '@nanocollective/prompt-scrub';
+
+const result = scrub({
+  content: prompt, // A string or an array of {role, content} objects
+  sessionId: "abc123" // Optional. If omitted, a new session is generated.
+});
+
+// result.scrubbedContent contains the text with placeholders
+// result.sessionId contains the session ID used
+```
+
+### `rehydrate`
+
+Restores the original identifying content into a model response.
+
+```typescript
+import { rehydrate } from '@nanocollective/prompt-scrub';
+
+const restored = rehydrate({
+  content: response, // The response from the LLM containing placeholders
+  sessionId: "abc123" // The session ID used during the scrub phase
+});
+
+// restored.content contains the rehydrated text
+// restored.warnings contains any placeholders hallucinated by the model
+```
+
+## Cache-Aware Determinism
+For a given session ID and input text, `scrub()` is **deterministic**. The system generates byte-identical output across repeated calls with the same map. This property is critical because it preserves provider prompt caching (which relies on exact prefix bytes).
+
+## Types
+
+```typescript
+export interface Message {
+  role: string;
+  content: string;
+}
+
+export interface ScrubRequest {
+  content: string | Message[];
+  sessionId?: string;
+  options?: ScrubOptions;
+}
+
+export interface ScrubOptions {
+  customDetectors?: Detector[];
+  disabledDetectors?: string[]; // Array of detector names to skip
+}
+
+export interface ScrubResult {
+  scrubbedContent: string | Message[];
+  sessionId: string;
+}
+
+export interface RehydrateRequest {
+  content: string;
+  sessionId: string;
+}
+
+export interface RehydrateResult {
+  content: string;
+  warnings?: string[]; // Populated if the model invents a placeholder not in the session map
+}
+```

--- a/content/collective/whitepapers/prompt-scrubber/getting-started/cli.md
+++ b/content/collective/whitepapers/prompt-scrubber/getting-started/cli.md
@@ -1,0 +1,52 @@
+---
+title: "Cli"
+description: "Documentation for Cli"
+sidebar_order: 1
+---
+
+# CLI Reference
+
+The `prompt-scrub` package provides a command-line interface for manual inspection, scripting, and pipeline integration. 
+
+## Core Commands
+
+### `prompt-scrub scrub [file]`
+Reads a message from `stdin` or a file and prints the scrubbed message to `stdout`. The session ID is printed to `stderr`.
+
+**Options:**
+- `--session-id <id>`: Reuse an existing session map. If omitted, a new UUID is generated.
+- `--disable <detectors>`: Comma-separated list of detectors to disable (e.g. `EmailDetector,PhoneDetector`).
+
+### `prompt-scrub rehydrate [file]`
+Reads a scrubbed response from `stdin` or a file and prints the rehydrated response to `stdout`.
+
+**Warnings (stderr):**
+If the model hallucinates a placeholder that does not exist in the session map (e.g., the model outputs `Secret_2` but only `Secret_1` was scrubbed), the tool passes the string through unchanged to `stdout`, but emits a warning directly to `stderr`.
+
+**Options:**
+- `--session-id <id>` (Required): The session ID used during the `scrub` phase to restore original values.
+
+### `prompt-scrub inspect [file]`
+Reads a message from `stdin` or a file and prints a human-readable diff of the transformations the scrubber will apply.
+
+**Options:**
+- `--disable <detectors>`: Comma-separated list of detectors to disable.
+
+## Session Management
+
+### `prompt-scrub sessions list`
+Lists all known session IDs currently stored on disk along with their file sizes.
+
+### `prompt-scrub sessions show <id>`
+Prints the raw JSON contents of a session map for inspection or manual editing.
+
+### `prompt-scrub sessions rm <id>`
+Deletes a session map from the disk permanently.
+
+## Utility
+
+### `prompt-scrub --version`
+Prints the current version of the CLI.
+
+### `prompt-scrub --help`
+Prints standard help documentation and available commands.

--- a/content/collective/whitepapers/prompt-scrubber/getting-started/examples.md
+++ b/content/collective/whitepapers/prompt-scrubber/getting-started/examples.md
@@ -1,0 +1,101 @@
+---
+title: "Examples"
+description: "Documentation for Examples"
+sidebar_order: 1
+---
+
+# Examples
+
+Here are some real-world examples of `prompt-scrub` in action.
+
+## Example 1: Basic Identifiers
+
+**Input**
+```text
+My email is akram@example.com
+API key: sk-123456
+```
+
+**Scrubbed**
+```text
+My email is Email_1
+API key: Secret_1
+```
+
+**Rehydrated**
+```text
+My email is akram@example.com
+API key: sk-123456
+```
+
+## Example 2: Paths and URLs
+
+**Input**
+```text
+I'm getting an error when fetching https://internal.company.com/api from /Users/akram/dev/app/src/main.ts
+```
+
+**Scrubbed**
+```text
+I'm getting an error when fetching Url_1 from Path_1
+```
+
+**Rehydrated**
+```text
+I'm getting an error when fetching https://internal.company.com/api from /Users/akram/dev/app/src/main.ts
+```
+
+## Example 3: The Limits of the Scrubber (Rich Example)
+
+**Input**
+```text
+Hey, I'm Will. My team is hitting a deploy failure on https://staging.acme-internal.io.
+The error from the GitHub Actions run is:
+  Error: secret not found: ANTHROPIC_API_KEY=sk-ant-abc123...
+  at /Users/will/work/acme/.github/workflows/deploy.yml:42
+Can you take a look?
+```
+
+**Scrubbed (assuming Name detector is opted-in)**
+```text
+Hey, I'm Name_1. My team is hitting a deploy failure on Url_1.
+The error from the GitHub Actions run is:
+  Error: secret not found: Secret_1
+  at Path_1
+Can you take a look?
+```
+
+**Model Response**
+```text
+The error means the workflow is trying to read ANTHROPIC_API_KEY from the environment. Check the Path_1 line. Also, never hardcode Secret_2 in your files.
+```
+
+**Rehydrated**
+```text
+The error means the workflow is trying to read ANTHROPIC_API_KEY from the environment. Check the /Users/will/work/acme/.github/workflows/deploy.yml line. Also, never hardcode Secret_2 in your files.
+```
+
+*Note: A warning is emitted to `stderr` indicating `Secret_2` was not found in the session map (the model hallucinated a placeholder). The library passes it through unchanged.*
+
+**What Slipped Through (The Gap):**
+The developer's writing style ("Hey, I'm Will. My team is hitting..."), the fact that they have a team, and the cadence of their question. Style fingerprinting is not solved in v1.
+
+## Example 4: Node.js Library Integration
+
+**Code**
+```typescript
+import { scrub, rehydrate } from '@nanocollective/prompt-scrub';
+
+const prompt = "My secret is sk-123456789";
+
+// 1. Scrub the prompt
+const { scrubbedContent, sessionId } = scrub({ content: prompt });
+console.log(scrubbedContent); // "My secret is Secret_1"
+
+// 2. Send to LLM...
+const response = "You shouldn't share Secret_1.";
+
+// 3. Rehydrate the response
+const { content } = rehydrate({ content: response, sessionId });
+console.log(content); // "You shouldn't share sk-123456789."
+```

--- a/content/collective/whitepapers/prompt-scrubber/getting-started/index.md
+++ b/content/collective/whitepapers/prompt-scrubber/getting-started/index.md
@@ -1,0 +1,15 @@
+---
+title: "Getting Started"
+description: "Get up and running"
+sidebar_order: 1
+---
+
+# Getting Started
+
+Welcome! In this section, you will learn how to set up `prompt-scrub` for your project or terminal.
+
+- [Installation](installation.md): Learn how to install the package globally or locally.
+- [Setup & Verification](setup.md): Verify your installation is working correctly.
+- [CLI Reference](cli.md): Learn how to use the `prompt-scrub` command-line tool.
+- [API Reference](api.md): Use `prompt-scrub` as a library in your Node.js application.
+- [Examples](examples.md): See real-world examples of how to use the tool.

--- a/content/collective/whitepapers/prompt-scrubber/getting-started/installation.md
+++ b/content/collective/whitepapers/prompt-scrubber/getting-started/installation.md
@@ -1,0 +1,27 @@
+---
+title: "Installation"
+description: "How to install prompt-scrub"
+sidebar_order: 2
+---
+
+# Installation
+
+There are two primary ways to install `prompt-scrub` depending on your use case: globally for the CLI, or locally as a project dependency.
+
+## Global CLI Installation
+
+If you want to use the `prompt-scrub` command directly from your terminal across your system:
+
+```bash
+npm install -g prompt-scrub
+```
+
+## Local Project Dependency
+
+If you are building an application and want to use `prompt-scrub` programmatically via its Node.js API:
+
+```bash
+npm install prompt-scrub
+```
+
+This will add it to your project's `node_modules` so you can import it in your code.

--- a/content/collective/whitepapers/prompt-scrubber/getting-started/setup.md
+++ b/content/collective/whitepapers/prompt-scrubber/getting-started/setup.md
@@ -1,0 +1,40 @@
+---
+title: "Setup & Verification"
+description: "Verify your installation"
+sidebar_order: 3
+---
+
+# Setup & Verification
+
+After installing `prompt-scrub`, you can verify that it is set up correctly by running a few quick commands.
+
+## Check Version
+
+Verify that the CLI is accessible and check the installed version:
+
+```bash
+prompt-scrub --version
+```
+
+## View Help
+
+Explore the available commands and options:
+
+```bash
+prompt-scrub --help
+```
+
+## Run a Smoke Test
+
+To ensure the scrubbing engine is functioning correctly, pipe a test string into the `scrub` command:
+
+```bash
+echo "My secret email is test@example.com" | prompt-scrub scrub
+```
+
+You should see an output similar to:
+```
+My secret email is Email_1
+```
+
+If these commands succeed, your installation is ready to use!

--- a/content/collective/whitepapers/prompt-scrubber/index.md
+++ b/content/collective/whitepapers/prompt-scrubber/index.md
@@ -1,0 +1,16 @@
+---
+title: "prompt-scrub"
+description: "Introduction to prompt-scrub"
+sidebar_order: 0
+proposer: "Will Lamerton"
+proposer_github: "will-lamerton"
+status: "Building"
+review_opens: "2026-05-19"
+review_closes: "2026-06-18"
+---
+
+# Welcome to prompt-scrub
+
+`prompt-scrub` is a local-first utility designed to strip identifying content out of prompts and messages before they hit any cloud LLM. 
+
+Jump into the [Getting Started](getting-started/index.md) section to install the CLI or library, or browse the [Features](features/index.md) to understand the underlying architecture and threat model.


### PR DESCRIPTION
Resolves  https://github.com/Nano-Collective/prompt-scrubber/issues/16

### Summary

This PR ingests the full `docs/` tree for the `prompt-scrub` project into the Nano Collective docs site, targeting the canonical whitepaper section. It replaces the original `prompt-scrubber.md` single-file whitepaper with the full docs tree prepared upstream. 

This work was dependent on the upstream cleanup PR #15 in the `prompt-scrub` repo, which is now merged and closed.

### Changes
- **Ingested the full docs tree**: Created `content/collective/whitepapers/prompt-scrubber/` containing the full playbook-compliant docs tree (`index.md`, `community.md`, `getting-started/*`, `features/*`).
- **Preserved Whitepaper Metadata**: Merged the required `proposer`, `status`, and `review_*` tags into the new root `index.md` so that the whitepaper badges and feedback widget continue to render correctly on the docs site.
- **Removed stale artifact**: Deleted the legacy `prompt-scrubber.md` file.