### PR TITLE
docs: update get-md description to include PDF, DOCX, and Markdown support

### DIFF
--- a/content/collective/index.md
+++ b/content/collective/index.md
@@ -40,7 +40,7 @@ The collective builds a range of AI tools and developer utilities. Some projects
 
 - **[Nanocoder](https://github.com/Nano-Collective/nanocoder)**: a coding agent in your terminal that runs on any model you choose.
 - **[Nanotune](https://github.com/Nano-Collective/nanotune)**: tooling focused on fine-tuning and improving small, local models for practical use.
-- **[get-md](https://github.com/Nano-Collective/get-md)**: a fast, lightweight HTML to Markdown converter optimised for LLM consumption.
+- **[get-md](https://github.com/Nano-Collective/get-md)**: a fast, lightweight HTML, PDF, DOCX, and Markdown to Markdown converter optimised for LLM consumption.
 - **[json-up](https://github.com/Nano-Collective/json-up)**: a type-safe JSON migration tool with Zod schema validation.
 
 Projects under the Nano Collective run independently. Each has its own maintainers, roadmap, and release cadence, but they share a consistent approach to how they are structured, tested, released, and presented. That consistency is deliberate. It makes the collective legible from the outside, lowers the barrier for contributors moving between projects, and ensures every tool we ship meets a shared bar for quality and openness.

--- a/content/collective/projects/contributing.md
+++ b/content/collective/projects/contributing.md
@@ -24,7 +24,7 @@ Every NC project lives at [github.com/Nano-Collective](https://github.com/Nano-C
 
 - **[Nanocoder](https://github.com/Nano-Collective/nanocoder)**: a coding agent in your terminal that runs on any model you choose.
 - **[Nanotune](https://github.com/Nano-Collective/nanotune)**: fine-tuning small models on Apple Silicon.
-- **[get-md](https://github.com/Nano-Collective/get-md)**: HTML to Markdown converter.
+- **[get-md](https://github.com/Nano-Collective/get-md)**: HTML, PDF, DOCX, and Markdown to Markdown converter.
 - **[json-up](https://github.com/Nano-Collective/json-up)**: JSON migration tool.
 
 Pick the one closest to what you actually use or care about.

--- a/content/collective/projects/index.md
+++ b/content/collective/projects/index.md
@@ -14,7 +14,7 @@ This is where the collective's mission becomes concrete. It is a home where anyo
 
 - **[Nanocoder](https://github.com/Nano-Collective/nanocoder)**: a coding agent in your terminal that runs on any model you choose.
 - **[Nanotune](https://github.com/Nano-Collective/nanotune)**: tooling focused on fine-tuning and improving small, local models for practical use.
-- **[get-md](https://github.com/Nano-Collective/get-md)**: a fast, lightweight HTML to Markdown converter optimised for LLM consumption.
+- **[get-md](https://github.com/Nano-Collective/get-md)**: a fast, lightweight HTML, PDF, DOCX, and Markdown to Markdown converter optimised for LLM consumption.
 - **[json-up](https://github.com/Nano-Collective/json-up)**: a type-safe JSON migration tool with Zod schema validation.
 
 Each project has its own dedicated documentation. The pages in this section cover the rules and conventions that apply across **all** Nano Collective projects, regardless of stack or domain.

--- a/lib/projects.ts
+++ b/lib/projects.ts
@@ -37,7 +37,7 @@ export const PROJECTS: ProjectConfig[] = [
     id: "get-md",
     name: "get-md",
     description:
-      "A fast, lightweight HTML to Markdown converter optimized for LLM consumption.",
+      "A fast, lightweight HTML, PDF, DOCX, and Markdown to Markdown converter optimized for LLM consumption.",
     type: "library",
     repo: {
       owner: "Nano-Collective",


### PR DESCRIPTION
**Description:**
This PR updates the documentation and repository descriptions for `get-md` across the docs site. 

Previously, `get-md` was described strictly as an "HTML to Markdown converter." This update revises the copy to accurately reflect its expanded capabilities, noting that it is now a "fast, lightweight HTML, PDF, DOCX, and Markdown to Markdown converter."