### PR TITLE
Nano-Bench: Finalize execution pipeline, dual-mode ablation, and taxonomy heuristics

### DIFF
--- a/content/collective/whitepapers/nanobench.md
+++ b/content/collective/whitepapers/nanobench.md
@@ -98,6 +98,12 @@ Every evaluation task is anchored to a specific, immutable repository state (e.g
 
 All tasks are sourced from real merged pull requests in real production repositories. No synthetic tasks. No LLM-generated task descriptions. The "Curation Paradox" is a guiding principle: **we cannot rely on an LLM to select the tasks we use to benchmark an LLM.** If an agent already possessed the architectural depth to distinguish a syntax fix from a multi-component reasoning bottleneck, this dataset would already be obsolete. Curation must be expert-led.
 
+### The Grading Paradox
+
+The same reasoning that governs task curation governs scoring. **If a model cannot be trusted to decide which tasks belong in the benchmark, it cannot be trusted to decide whether a run of that benchmark succeeded**. For this reason, every terminal state in NanoBench — pass, partial
+pass, or failure category — is assigned by a deterministic rule engine reading structured telemetry, never by a model reading logs and rendering a judgment.
+**Section 9.1 defines this mechanism in full.**
+
 ### Transparency
 
 Every structural decision—from repository selection to the final scoring rationale—is fully auditable. Instead of black-box curation, a transparent engine scores and ranks repositories based on objective complexity metrics. Furthermore, every evaluation task exposes its complete metadata to the community, including the original issue context, the expert-verified golden patch, and the exact verification commands.
@@ -183,6 +189,19 @@ To ensure rigorous, objective, and consistent curation across all current and fu
 | Domain novelty | 4 | 0 if domain already covered; 2 if adjacent; 4 if new domain |
 | Context pressure | 4 | >80k tokens = 4pts; 50–80k = 3pts; 20–50k = 2pts; <20k = 0pts |
 
+### Architectural Complexity Tiers
+
+To systematically probe an agent's reasoning depth, NanoBench abandons simplistic line-count metrics in favor of four **Architectural Complexity Tiers**. These tiers categorize the cognitive load and reasoning radius required to solve the task. 
+
+Crucially, this taxonomy is grounded in mechanistic interpretability research regarding how Large Language Models encode hierarchical structure. Transformer layers encode progressively more abstract representations: shallow layers process local syntactic patterns, middle layers build relational graphs (e.g., imports and function calls), and deep layers encode abstract systemic invariants. NanoBench's tiers map directly to this cognitive architecture:
+
+| Tier | Designation | Cognitive Radius | Target Agent Behavior | Diagnostic Implication |
+| :--- | :--- | :--- | :--- | :--- |
+| **Tier 1** | **Isolated Edit** | Localized syntax/logic within a single file. | Read file → identify logic gap → edit. | **Baseline Competence.** Models failing here lack fundamental code comprehension. Run-to-run variance should be zero. |
+| **Tier 2** | **Interface Mapping** | Tracing dependencies across 2–5 files. | Search → trace import chains → reconcile interface contracts. | **Relational Reasoning.** Tests the middle transformer layers. Failure indicates an inability to maintain coherent state across API boundaries. |
+| **Tier 3** | **System Refactor** | Comprehending module graphs and invariants across 5–15 files. | Investigate structure → map dependencies → plan → execute multi-file changes. | **Architectural Abstraction.** Tests deep transformer layers. Failure indicates the agent's planning capacity breaks down when coordinating system-wide rules. |
+| **Tier 4** | **Investigative Debugging** | Multi-step hypothesis testing where root causes are obfuscated. | Investigate → form hypothesis → test → refine → implement. | **Sustained Inference.** The ceiling task. High run-to-run variance is expected here, separating standard models from frontier reasoning engines. |
+
 ### Task Extraction Methodology
 
 Tasks are extracted exclusively from real merged pull requests, not from open issues or synthetic generation. The extraction process:
@@ -196,7 +215,7 @@ Tasks are extracted exclusively from real merged pull requests, not from open is
 
 ### Task Schema
 
-Every curated task is compiled into a standardized, machine-readable metadata schema. This schema guarantees that the orchestrator has all the necessary parameters to run the evaluation deterministically. The schema enforces four core metadata categories: Fpr Example :
+Every curated task is compiled into a standardized, machine-readable metadata schema. This schema guarantees that the orchestrator has all the necessary parameters to run the evaluation deterministically. The schema enforces four core metadata categories: For Example :
 
 ```json
 {
@@ -208,7 +227,7 @@ Every curated task is compiled into a standardized, machine-readable metadata sc
   "base_commit": "<sha>",
   "languages": ["python", "jax"],
   "domain": "scientific computing",
-  "difficulty": "very-hard",
+  "complexity_tier": "Tier 3 (System Refactor)",
   "task_type": "feature",
   "reasoning_category": "functional_flow_integrity",
   "token_estimate": 52000,
@@ -298,41 +317,119 @@ Each evaluation run deterministically produces three primary artifacts:
 
 ## 9. Failure Taxonomy
 
-The failure taxonomy is the primary diagnostic payload generated by the benchmark. Binary score improvements (e.g., shifting from 52% to 55%) provide zero actionable signal to model developers or framework maintainers. Conversely, observing that `insufficient_context_read` failures dropped from 62% to 21% after an update to a prompt builder provides exact, targeted telemetry
+The failure taxonomy is the primary diagnostic payload generated by the benchmark. Binary score improvements (e.g., shifting from 52% to 55%) provide zero actionable signal to model developers or framework maintainers. Conversely, observing that `insufficient_context_read` failures dropped from 62% to 21% after an update to a prompt builder provides exact, targeted telemetry.
+
+### 9.1 Classification Mechanism
+
+Every failure category in this taxonomy is assigned by a deterministic rule
+engine, not a model. The engine reads only structured fields that already exist in Nanocoder's `--json` run report — `toolCalls[]`, `filesChanged[]`, exit codes, and, once the upstream `usage` block lands, token counts together with the static `required_files` array from the task schema. No log text is summarized or judged by an LLM at any point in this pipeline. This follows directly from the Grading Paradox in §4: a benchmark that will not let a model pick its own tasks should not let a model decide why it failed one.
+
+**Assignment order.** A run's terminal state is checked against the six
+categories in a fixed sequence. The first rule that matches is the label that
+is applied, and no later rule is evaluated once a match is found. This removes
+the need for a "which one is more severe" judgment call — the order itself is
+the precedence rule.
+
+1. **Execution halted before any edit.** If Nanocoder exits on a context-size
+   or rate-limit error and `filesChanged[]` is empty, the run is
+   `context_window_exceeded`, regardless of what a test run might otherwise
+   have shown. A run that never reached the point of editing code cannot also
+   be a partial fix.
+2. **No required-file overlap.** If nothing in `filesChanged[]` intersects
+   `required_files`, the run is `insufficient_context_read` in Navigation Mode,
+   or scores 0.0 (Zero Signal) in Hinted Mode — checked before any test output
+   is inspected.
+3. **Required-file overlap, full failure, missing-symbol error.** If
+   `filesChanged[]` intersects `required_files` but the test run fails on an
+   `AttributeError` or `NameError` referencing a symbol that does not exist in
+   the historical state of `required_files`, the run is `hallucinated_api`.
+4. **Required-file overlap, full failure, interface-level error.** Same
+   overlap condition as above, but the failure is a type or interface mismatch
+   rather than a missing symbol: `wrong_abstraction_layer`.
+5. **Partial test pass.** If at least 50% of target tests pass and
+   required-file overlap is nonzero, the run is `partial_fix_only`. This rule
+   is only reached if rules 1–4 did not match, so a run that partially passed
+   despite an earlier context warning is still scored as a genuine partial
+   fix — the run produced a gradable artifact, which is the stronger signal.
+6. **Cross-language split (Navigation Mode, polyglot tasks only).** One
+   language's test suite passes fully while another fails:
+   `missing_cross_language_change`.
+**Structurally impossible overlaps.** Some category pairs cannot both apply to
+the same run, by construction rather than by rule ordering:
+ 
+| Category A | Category B | Why they cannot co-occur |
+|---|---|---|
+| `context_window_exceeded` | `partial_fix_only` | The former requires `filesChanged[]` to be empty; the latter requires nonzero required-file overlap. |
+| `context_window_exceeded` | `hallucinated_api` / `wrong_abstraction_layer` | Both require a completed test run; a context-exhausted run never reaches `test_command`. |
+| `hallucinated_api` | `wrong_abstraction_layer` | Both require full test failure with required-file overlap, but are separated by error type (missing symbol vs. interface mismatch) — a single failure has one dominant error type, checked in fixed order. |
+ 
+**Open limitation.** Rules 3 and 4 depend on string-matching exception types
+inside a stack trace, which is more fragile than the pure `filesChanged[]`
+overlap checks used by every other rule. This is the least deterministic part
+of the taxonomy today, and it is treated as such — see the updated open
+question in §14 for how this gets validated before it is trusted at scale.
+ 
+---
+
+### 9.2 Signal Confidence Level(1-4)
+ 
+Not every diagnostic signal in this taxonomy carries the same certainty. Some
+come straight from structured fields with no interpretation required; others
+depend on matching text inside an error message, which is inherently less
+reliable. NanoBench makes this explicit with four confidence levels, ranked from most to least direct:
+ 
+- **Level 1 — Structural signal.** Computed purely from `filesChanged[]`
+  against `required_files`. No interpretation involved. Backs
+  `insufficient_context_read`, `partial_fix_only`, and
+  `missing_cross_language_change`.
+- **Level 2 — Outcome signal.** Pass/fail counts from `test_command`,produced
+  by the target repository's own test runner rather than by Nanocoder. Backs
+  the 0.5 / 1.0 scoring thresholds directly.
+- **Level 3 — Process signal.** Nanocoder's own exit code, e.g. a context-size or rate-limit error. Deterministic, but its accuracy is only as good as
+  Nanocoder's own error reporting — the same upstream dependency already noted
+  in §8 regarding the `usage` block.
+- **Level 4 — Content signal.** String-matching against exception type inside a
+  stack trace. Backs `hallucinated_api` and `wrong_abstraction_layer`. This is
+  the least certain level in the taxonomy and is flagged as a known limitation
+  rather than presented as equally reliable to Levels 1–3.
+Each category below is tagged with its level so the taxonomy states its own
+confidence level rather than leaving it implicit.
+ 
+---
 
 NanoBench maps terminal states to six strict diagnostic categories:
 
-### Hallucinated APIs (`hallucinated_api`)
+### Hallucinated APIs (`hallucinated_api`)→ Level 4
 
 The agent calls a method or accesses an attribute that does not exist in the historical state of the codebase. This is highly common in repositories with complex, evolving SDKs or strict functional paradigms that prohibit imperative mutations.
 
 *Diagnostic signal: test fails with `AttributeError` or `NameError` on a symbol that doesn't exist in `required_files`.*
 
-### Insufficient Context Reading (`insufficient_context_read`)
+### Insufficient Context Reading (`insufficient_context_read`)→ Level 1
 
 The agent failed to read enough of the repository to map the architectural dependencies before executing changes. This manifests as surface-level logic edits that miss the underlying data flow. Agents may read dozens of files, but fail to locate the actual architectural bottleneck.
 
 *Diagnostic signal: `files_read` is high but `required_files` overlap with `files_edited` is low.*
 
-### Wrong Abstraction Layer (`wrong_abstraction_layer`)
+### Wrong Abstraction Layer (`wrong_abstraction_layer`)→ Level 4
 
 The agent injected its logic at the incorrect level of the architecture—for example, editing a high-level interface contract when the fix was actually required in the underlying implementation driver. This is heavily prevalent in deep, plugin-based frameworks.
 
 *Diagnostic signal: agent touched files from `required_files` but tests still fail with an interface mismatch error.*
 
-### Missing Cross-Component Changes (`missing_cross_language_change`)
+### Missing Cross-Component Changes (`missing_cross_language_change`)→ Level 1
 
 The agent successfully fixed one localized component but missed a parallel architectural change required in another language or package. This routinely occurs in polyglot, full-stack environments (e.g., updating a backend schema but ignoring the frontend state manager).
 
 *Diagnostic signal: partial tests pass (one language's tests) but the other language's tests fail.*
 
-### Context Window Exhaustion (`context_window_exceeded`)
+### Context Window Exhaustion (`context_window_exceeded`)→ Level 3
 
 The agent exhausted its context window or API token budget before outputting a viable patch. High-complexity architectural tasks frequently exceed standard context limits, proving that current agents struggle to navigate large-scale repositories without highly optimized retrieval.
 
 *Diagnostic signal: Nanocoder exits with a context-size error or rate-limit error before `test_command` is reached.*
 
-### Partial Fixes (`partial_fix_only`)
+### Partial Fixes (`partial_fix_only`) Level 1 + Level 2
 
 The agent successfully implemented correct logic for a subset of the task but failed to catch all required edge cases. This triggers fractional scoring (0.5) because the agent demonstrated strict directional and partial functional correctness.
 
@@ -465,9 +562,9 @@ with Nanocoder? This affects long-term maintainability and contributor
 onboarding friction.
 
 ### Automated vs. Human Evaluation
-Scoring is fully automated via native test suites. Should an optional
-human-in-the-loop review layer be introduced for partial-resolution tasks,
-to distinguish correct-but-incomplete logic from plausible hallucinations?
+ 
+Scoring is fully automated via native test suites, and category assignment is
+fully automated via the deterministic rule engine in §9.1. The one part of the taxonomy that is not yet independently validated is Level 4: the string-matching rules that separate `hallucinated_api` from `wrong_abstraction_layer`. Before these two categories are treated as trustworthy at scale, a human-reviewed spot-check against a sample of runs is needed — specifically checking whether the exception-type matching rule agrees with a human reading the same stack trace. This is a narrower and more concrete question than general human-in-the-loop review of partial-resolution scores, and it is the one open item that most directly affects whether the taxonomy's headline categories can be cited with confidence.
 
 ### Community Contribution Gates
 What programmatic validation requirements must a community-submitted task

--- a/content/collective/whitepapers/nanobench.md
+++ b/content/collective/whitepapers/nanobench.md
@@ -215,7 +215,7 @@ Tasks are extracted exclusively from real merged pull requests, not from open is
 
 ### Task Schema
 
-Every curated task is compiled into a standardized, machine-readable metadata schema. This schema guarantees that the orchestrator has all the necessary parameters to run the evaluation deterministically. The schema enforces four core metadata categories: For Example :
+Every curated task is compiled into a standardized, machine-readable metadata schema. This schema guarantees that the orchestrator has all the necessary parameters to run the evaluation deterministically. The schema enforces four core metadata categories: for example:
 
 ```json
 {
@@ -275,7 +275,7 @@ nanocoder \
 - `--mode yolo`: auto-accepts all tool calls, including bash execution, without prompting.
 - `--trust-directory`: skips the first-run directory trust prompt (ephemeral, does not modify `trustedDirectories`).
 - `--provider` / `--model`: fully specify the agent stack being evaluated. 
-- ` --plain` / `--json`: bypasses the interactive Ink.js UI and emits a structured JSON report (`{ kind, exitCode, toolCalls[], filesChanged[] }`) directly to `stdout` for deterministic parsing.
+- ` --plain` / `--json`: bypasses the interactive Ink.js UI and emits a structured JSON report (`{ kind, exitCode, toolCalls[], filesChanged[], temperature }`) directly to `stdout` for deterministic parsing. The `temperature` field records the actual sampling parameter used for the run, per §8.5.
 
 Note on Token Tracking: To fully support the `context_window_exceeded` failure taxonomy, NanoBench will coordinate a minor upstream feature request with the Nano Collective to add a `usage` block (token counts) to the existing `--json` run report.
 
@@ -302,6 +302,56 @@ The performance delta between these two modes serves as a novel diagnostic metri
 ### Partial Credit
 
 The 50% threshold for partial pass is intentional. A task with 10 test cases should not score 0.0 simply because one edge case was missed — that conflates "wrong direction" with "nearly right." The threshold requires both directional correctness (touched the right files) and substantive correctness (at least half the tests pass).
+
+### 8.5 Run Variance & Sampling Policy
+ 
+LLM sampling is stochastic. The same task, run twice on the same model, can
+pass once and fail once. §7 already asserts that this variance is not uniform
+across tiers — Tier 1 tasks are expected to have close to zero run-to-run
+variance, while Tier 4 tasks are expected to have high variance. NanoBench
+turns that assertion into an actual sampling policy, so the claim can be
+checked rather than taken on faith.
+ 
+**Runs per task.** The number of runs per task is set by its Architectural
+Complexity Tier, not applied uniformly:
+ 
+- **Tier 1–2:** 1 run per task per model. These tasks are expected to be
+  near-deterministic, so repeated sampling adds cost without adding signal.
+  Used directly in CI regression checks.
+- **Tier 3–4:** 5 runs per task per model, minimum, before any score from
+  these tasks is used in a regression comparison. This is a higher bar than
+  typical CI eval sampling, because NanoBench's Tier 3–4 tasks are more
+  expensive and more architecturally demanding per run — getting the sample
+  size right matters more here, not less.
+**Score reporting.** Every task reports two numbers, not one:
+ 
+- `pass@1` — the result of a single run. Cheap, useful as a smoke-test signal,
+  but not used alone for regression claims on Tier 3–4 tasks.
+- Averaged score over N runs — the number actually used for trend comparisons
+  and the Provider Matrix in §8's Benchmark Outputs.
+Both the raw pass count (e.g. "3/5 runs passed") and the derived score are
+shown in the output report, so a reader can see the sample size behind any
+number rather than a single smoothed percentage.
+ 
+**Temperature.** Temperature is pinned to 0 by default for every provider
+that supports it. The actual temperature used is recorded per run in the
+`--json` telemetry (see §8's Execution Pipeline). Where a provider or model
+does not support temperature 0 — some hosted reasoning models force sampling
+— the run is explicitly flagged as non-deterministic in the output, so a
+reviewer can tell whether spread in a Tier 3/4 result comes from the task's
+difficulty or from an unpinned sampling parameter.
+ 
+**What counts as a real regression.** A raw point-estimate comparison (for
+example, "52% dropped to 55%") is not enough to claim a regression at
+NanoBench's dataset size — a single flipped task can move the aggregate by a
+large margin on its own. Instead, each aggregate score is reported with a
+confidence interval computed from its N runs (a Wilson interval on the pass
+rate). Two scores are only treated as a real regression or improvement if
+their intervals do not overlap. If the intervals overlap, the report labels
+the movement as "not distinguishable from noise" instead of presenting it as
+a finding.
+ 
+---
 
 ### Benchmark Outputs
 
@@ -371,7 +421,7 @@ question in §14 for how this gets validated before it is trusted at scale.
  
 ---
 
-### 9.2 Signal Confidence Level(1-4)
+### 9.2 Signal Confidence Level (1-4)
  
 Not every diagnostic signal in this taxonomy carries the same certainty. Some
 come straight from structured fields with no interpretation required; others
@@ -429,7 +479,7 @@ The agent exhausted its context window or API token budget before outputting a v
 
 *Diagnostic signal: Nanocoder exits with a context-size error or rate-limit error before `test_command` is reached.*
 
-### Partial Fixes (`partial_fix_only`) Level 1 + Level 2
+### Partial Fixes (`partial_fix_only`) →  Level 1 + Level 2
 
 The agent successfully implemented correct logic for a subset of the task but failed to catch all required edge cases. This triggers fractional scoring (0.5) because the agent demonstrated strict directional and partial functional correctness.
 
@@ -525,6 +575,22 @@ configuration. Polyglot environments run inside fully containerized sandboxes, e
 
 **Mitigation:** NanoBench utilizes **Hinted Mode** as the default execution path. By injecting expert metadata, the framework prevents runaway API costs caused by unbounded file exploration, making it financially feasible to run continuous CI regressions. Maintainers can selectively trigger **Navigation Mode** for deep-dive pathfinding evaluations when token budgets permit.
 
+### Statistical Power at v1 Scale
+**Risk:** With a v1 dataset of roughly 6 tasks, each task carries a large
+share of the aggregate score. A single task flipping from pass to fail can
+move the overall number by a large margin — larger than many of the real
+regressions the benchmark is meant to catch. At this scale, it is genuinely
+hard to tell a real regression from ordinary run-to-run noise.
+ 
+**Mitigation:** This is a known and bounded limitation, not a hidden one. The
+sampling and confidence-interval policy in §8.5 is the short-term mitigation:
+wide confidence intervals at v1 scale will correctly show up as wide, and the
+report will say so rather than presenting a noisy point estimate as a
+finding. The long-term fix is dataset growth — §15's v2/v3 roadmap already
+plans to expand the task count, which is what actually narrows the intervals.
+v1's regression-detection claim should be read as directionally useful but
+statistically weak, with that weakness improving as the dataset grows.
+ 
 ### Benchmark Bias
 **Risk:** Tasks curated by one person reflect a narrow domain slice.
 
@@ -582,7 +648,7 @@ disputes? This is a collective-level decision, not a technical one.
 
 ### Version 1.0 Deliverables
 
-- Curated Diagnostic Dataset: A foundational matrix of 6 high-complexity, multi-file tasks spanning diverse, polyglot architectural environments, with all states strictly pinned and validated.
+- Curated Diagnostic Dataset: A foundational matrix of 6 high-complexity, multi-file tasks spanning diverse, polyglot architectural environments, with all states strictly pinned and validated. This 6-task set is a starting point for the sampling and confidence-interval methodology in §8.5, not a target ceiling — v2/v3 dataset growth (below) is the primary lever for narrowing confidence intervals and strengthening the regression-detection claim in §2.
 
 - Automated Orchestration Engine: A headless, fully automated evaluation pipeline that dynamically injects boundaries, triggers Nanocoder in non-interactive mode, and extracts fractional scores via native test suites.
 

--- a/content/collective/whitepapers/nanobench.md
+++ b/content/collective/whitepapers/nanobench.md
@@ -260,6 +260,17 @@ nanocoder \
 
 Note on Token Tracking: To fully support the `context_window_exceeded` failure taxonomy, NanoBench will coordinate a minor upstream feature request with the Nano Collective to add a `usage` block (token counts) to the existing `--json` run report.
 
+### Execution Modes & The Navigation Delta
+
+Unconstrained codebase exploration is highly token-intensive. Early dry-runs on complex repositories  demonstrated that agents often exhaust standard API tier quotas purely on file exploration before attempting a fix—resulting in a 0.0 score for quota exhaustion rather than an architectural failure. 
+
+To reconcile the tradeoff between measuring navigation and maintaining reproducible run costs, NanoBench defines two evaluation modes:
+
+1. **Hinted Mode (Default):** The agent receives the `<problem_statement>` appended with the `<required_files>` metadata array. This isolates pure implementation ability. Given the right architectural map, can the agent produce a correct fix? Categories like `hallucinated_api` and `wrong_abstraction_layer` are primarily measured here.
+2. **Navigation Mode (Opt-in):** The agent receives *only* the problem statement. This tests the full stack: can the agent find *and* fix the bug? The `0.1 Pathfinding Credit` and `insufficient_context_read` signals are only meaningful—and only awarded—when running in this mode.
+
+The performance delta between these two modes serves as a novel diagnostic metric, quantifying exactly how much of a given model's failure rate is caused by poor pathfinding versus poor implementation.
+
 ### Scoring Strategy
 
 | Score | Label | Condition |
@@ -415,7 +426,7 @@ configuration. Polyglot environments run inside fully containerized sandboxes, e
 ### Evaluation Cost
 **Risk:** Multi-provider evaluations at scale incur high API costs and hit rate limits.
 
-**Mitigation:** Expert-metadata injection reduces unnecessary file exploration significantly, cutting both cost and run time. Local open-weight models provide a cost-free baseline for comparison.
+**Mitigation:** NanoBench utilizes **Hinted Mode** as the default execution path. By injecting expert metadata, the framework prevents runaway API costs caused by unbounded file exploration, making it financially feasible to run continuous CI regressions. Maintainers can selectively trigger **Navigation Mode** for deep-dive pathfinding evaluations when token budgets permit.
 
 ### Benchmark Bias
 **Risk:** Tasks curated by one person reflect a narrow domain slice.

--- a/content/collective/whitepapers/nanobench.md
+++ b/content/collective/whitepapers/nanobench.md
@@ -148,13 +148,13 @@ NanoBench aims to become the standard evaluation suite for the Nano Collective's
             │
             ▼
 ┌───────────────────────────────────────┐
-│     Headless Execution Loop           │ ──► Invokes Nanocoder via a true --headless flag,
+│     Headless Execution Loop           │ ──► Invokes Nanocoder via --plain --json flags,
 └───────────────────────────────────────┘     bypassing the Ink.js interactive render tree
             │
             ▼
 ┌───────────────────────────────────────┐
-│     Deterministic Telemetry Sink      │ ──► Nanocoder flushes a raw JSON log trace
-└───────────────────────────────────────┘     directly to a structured disk file
+│     Deterministic Telemetry Capture   │ ──► The orchestrator captures the structured JSON
+└───────────────────────────────────────┘      run report directly from stdout
             │
             ▼
 ┌───────────────────────────────────────┐
@@ -240,23 +240,25 @@ The dataset is versioned via Git tags (`v0.1`, `v1.0`, etc.). Every `base_commit
 
 ### Execution Pipeline
 
-NanoBench invokes Nanocoder in non-interactive run mode — the same mode Nanocoder v1.19.0 explicitly designed for CI/CD pipelines and automation scripts:
+NanoBench invokes Nanocoder in non-interactive run mode — the same mode Nanocoder explicitly designed for CI/CD pipelines and automation scripts:
 
 ```bash
 nanocoder \
   --provider <provider> \
   --model <model> \
   --mode yolo \
-  --trust \
+  --trust-directory \
+  --plain \
+  --json \
   run "<problem_statement>\n\nKey files to focus on:\n<required_files>"
 ```
 
 - `--mode yolo`: auto-accepts all tool calls, including bash execution, without prompting.
-- `--trust`: skips the first-run directory trust prompt (ephemeral, does not modify `trustedDirectories`).
-- `--provider` / `--model`: fully specify the agent stack being evaluated. The same command with different provider/model flags produces a directly comparable result on the same task.
+- `--trust-directory`: skips the first-run directory trust prompt (ephemeral, does not modify `trustedDirectories`).
+- `--provider` / `--model`: fully specify the agent stack being evaluated. 
+- ` --plain` / `--json`: bypasses the interactive Ink.js UI and emits a structured JSON report (`{ kind, exitCode, toolCalls[], filesChanged[] }`) directly to `stdout` for deterministic parsing.
 
-Nanocoder's `--plain` flag (introduced in v1.26.0) can optionally be used for cleaner stdout capture in CI pipelines.
-
+Note on Token Tracking: To fully support the `context_window_exceeded` failure taxonomy, NanoBench will coordinate a minor upstream feature request with the Nano Collective to add a `usage` block (token counts) to the existing `--json` run report.
 
 ### Scoring Strategy
 
@@ -275,7 +277,7 @@ The 50% threshold for partial pass is intentional. A task with 10 test cases sho
 
 Each evaluation run deterministically produces three primary artifacts:
 
-- **Raw Telemetry Output**: A structured data payload (JSON) containing per-task execution metrics, including the tiered score, failure classification, model/provider metadata, total tokens consumed, tool-call frequency, and execution time.
+- **Raw Telemetry Output**: Extracted directly from Nanocoder's `--json` `stdout` payload, this report exposes `toolCalls[]` and `filesChanged[]` to compute exactly what files were read and edited, mapping directly to the failure taxonomy.
 
 - **Aggregated Baseline Report**: A human-readable synthesis document breaking down aggregated scores across multiple dimensions: provider, model, reasoning category, language, domain, and token density.
 


### PR DESCRIPTION
### Desciption 1

- Replace hypothetical `--headless` and disk logging with actual `--plain` and `--json` stdout capture.
- Correct `--trust` flag to `--trust-directory`.
- Update telemetry section to explicitly reference `toolCalls[]` and `filesChanged[]` for failure taxonomy.
- Add note regarding upstream feature request for token usage tracking.

Resolves #30

### Desciption 2

- Define `Hinted Mode` (default) and `Navigation Mode` (opt-in) in Section 8 to decouple pure coding from pathfinding.
- Clarify that `0.1 Pathfinding Credit` and `insufficient_context_read` are strictly tied to Navigation Mode.
- Document the previous dry-run API exhaustion context as the primary driver for default metadata injection.
- Update cost mitigations in Section 12 to reflect the new execution modes.

Resolves #31

### Desciption 3

- Added **§8.5: Run Variance & Sampling Policy**: Formalizes how NanoBench handles stochastic noise. It mandates `temperature=0`, defines dynamic sample sizing based on the task's Complexity Tier, and requires non-overlapping confidence intervals to declare a true regression.
- Updated **§12 (Risks)** and **§15 (Roadmap)** to explicitly state that v1's 6-task scale is a structural pipeline validation, and statistical power will organically scale in v2/v3.

Resolves #32 

### Description 4

- Define "The Grading Paradox" (§4), explicitly forbidding LLMs from judging terminal states.
- Introduce deterministic classification mechanism (§9.1) featuring strict precedence rules and structurally impossible overlap mapping.
- Establish Signal Confidence Tiers (§9.2) to transparently rank the reliability of diagnostic telemetry (Tier 1 structural vs. Tier 4 content).
- Refine open questions (§14) to target human validation specifically on Tier 4 string-matching heuristics.

Resolves #33